### PR TITLE
🚑 hotfix: Spinner/#165

### DIFF
--- a/src/components/ui/Spinner/index.tsx
+++ b/src/components/ui/Spinner/index.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
 import * as S from './style'
-export const Spinner = ({ width }: { width: string }) => {
+interface Props {
+  width?: string
+}
+export const Spinner = ({ width }: Props) => {
   return <S.Container width={width} />
 }

--- a/src/components/ui/Spinner/style.ts
+++ b/src/components/ui/Spinner/style.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
 interface Props {
-  width: string
+  width?: string
 }
 export const Container = styled.div<Props>`
   margin: 0 auto;


### PR DESCRIPTION
## <img src='https://emojis.slackmojis.com/emojis/images/1643514558/5570/confused_dog.gif?1643514558' alt='개요' width=30px> 개요
제가 바꾼 Spinner쪽 props로 인해 다른쪽에서 타입 에러가 생겨 Spinner쪽의 타입을 수정했습니다

## <img src='https://emojis.slackmojis.com/emojis/images/1643514738/7421/typingcat.gif?1643514738' alt='작업 사항' width=30px> 작업 사항

type
- [x] 공통 사용 및 배포를 위한 타입 수정

## 이슈 번호
#165 
